### PR TITLE
ESLint: Ignore errors in test.js

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 QUnit.config.reorder = false;
 const { test } = QUnit;
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/* eslint-disable no-undef */
 
 QUnit.config.reorder = false;
 const { test } = QUnit;


### PR DESCRIPTION
If one uses the [portsoc linter config](https://github.com/portsoc/eslint-config-portsoc) doing these tasks, they'll find their IDE still showing 105 errors in `test.js`, even if they have written tests in `index.js` 'perfectly.'

It might be an idea to only ignore specific errors that are inevitable in this scenario, like functions not being defined, rather than all errors?

![A screenshot of an IDE: A list of errors, with sad red crosses and red underlined code](https://github.com/user-attachments/assets/4d391961-0651-44f0-8163-c287e2387d4e)

![Screenshot of an IDE: a red cross, with the number '105' next to it](https://github.com/user-attachments/assets/437039a6-96c8-437c-802f-e8012e77f495)
